### PR TITLE
Missing FABRIC_TAG for CORE_CHAINCODE_BUILDER & Deprecated ami for AmazonLinux2

### DIFF
--- a/eks/eks-amzlinux.yaml
+++ b/eks/eks-amzlinux.yaml
@@ -72,7 +72,7 @@ nodeGroups:
     #amiFamily: Ubuntu1804
 
     #AmazonLinux AMI and Family
-    ami: ami-0d275f57a60281ccc
+    ami: ami-0365ad3c8cfd3cb4c
     amiFamily: AmazonLinux2
     volumeEncrypted: true
     #Isolate nodegroup from the public internet

--- a/mamba/blockchain/peer/commands.py
+++ b/mamba/blockchain/peer/commands.py
@@ -64,6 +64,7 @@ def setup_peer(peer, index):
         'PEER_ORG': peer,
         'PEER_DOMAIN': domain,
         'PEER_INDEX': index,
+        'FABRIC_TAG': settings.FABRIC_TAG,
         'EFS_SERVER': settings.EFS_SERVER,
         'EFS_PATH': settings.EFS_PATH,
         'EFS_EXTEND': settings.EFS_EXTEND,


### PR DESCRIPTION
1. When "INIT CHAINCODE" I got this this error:

```
##### 2020-08-13 06:44:58 INIT CHAINCODE
 {"success":false,"message":"Failed to instantiate. cause: Failed to send Proposal and receive all good ProposalResponse.
proposalResponses [0]: error starting container: error starting container: 
Failed to generate platform-specific docker build: Failed to pull hyperledger/fabric-ccenv:{{FABRIC_TAG}}: 
API error (400): invalid reference format,proposalResponses [1]: error starting container: error starting container: 
Failed to generate platform-specific docker build: Failed to pull hyperledger/fabric-ccenv:{{FABRIC_TAG}}: 
API error (400): invalid reference format"}
```

2. "ami-0d275f57a60281ccc" for AmazonLinux2 is deprecated, therefore these worker nodes can't join NodeGroup when setting up EKS. I use "ami-0365ad3c8cfd3cb4c" instead of.