### PR TITLE
Update Guideline and fix some bugs

### DIFF
--- a/REMOTE_ORG.md
+++ b/REMOTE_ORG.md
@@ -1,44 +1,46 @@
 1. Start network
-```
-mamba -config='config/operator.env' --set-default
+```bash
 mamba start
 ```
-
-2. Prepare merchant
+2. Prepare merchant config in '/home/hainq/.akachain/akc-mamba/mamba/config/merchant.env'
+- In merchant env, must fill:
+  - EXTERNAL_ORDERER_ADDRESSES, EXTERNAL_RCA_ADDRESSES
+  - ENDORSEMENT_ORG_NAME, ENDORSEMENT_ORG_ADDRESS, ENDORSEMENT_ORG_TLSCERT
+- In operator env, must fill:
+  - NEW_ORG_NAME
 ```
-mamba -config='config/merchant.env' --set-default
+cp /home/hainq/.akachain/akc-mamba/mamba/config/merchant.env /home/hainq/.akachain/akc-mamba/mamba/config/.env
+```
+- Prepare folder of merchant cluster using command:
+```
 mamba copyscripts
 ```
-
-3. Copy /tmp/artifact/cluster-operator-demo/akc-ca-data/rca-akc-cert.pem from operator cluster to merchant cluster: /tmp/artifact/cluster-merchant-demo/akc-ca-data/rca-akc-cert.pem
+3. Copy signed cert of root ca to merchant cluster
 ```
-cp /tmp/artifact/cluster-example/akc-ca-data/rca-akc-cert.pem /tmp/artifact/cluster-merchant-example/akc-ca-data/
+kubectl exec -it test-efs-7759545f7-b5ffw bash
+cp /tmp/artifact/akc-network/akc-ca-data/rca-akc-cert.pem /tmp/artifact/merchant-network/akc-ca-data/
 ```
 
-4. Setup external address orderer, rca
-
-5. Create new org
+4. Create new org in new cluster
 ```
 mamba create-org
 ```
-Output: ica, peer, admin, network-config, merchant.yaml, merchant.json
-6. Copy merchant.json từ merchant cluster (/tmp/artifact/cluster-merchant-demo/akc-ca-data/merchant.json) sang operator cluster (/tmp/artifact/cluster-operator-demo/akc-ca-data/merchant.json)
-
+-> Automation generate to merchant.json
+4. Copy merchant.json to operator cluster
 ```
-cp /tmp/artifact/cluster-merchant-example/akc-ca-data/remotetest.json /tmp/artifact/cluster-example/akc-ca-data/
+cp /tmp/artifact/merchant-network/akc-ca-data/merchant.json /tmp/artifact/akc-network/akc-ca-data/
 ```
-7. update config channel (support channel have 1 org)
-
+5. In operator cluster, add merchant to channel
+Must specify env: NEW_ORG_NAME="merchant" in operator.env file
 ```
-mamba -config='config/operator.env' --set-default
+cp /home/hainq/.akachain/akc-mamba/mamba/config/operator.env /home/hainq/.akachain/akc-mamba/mamba/config/.env
 mamba channel-config auto-update
 ```
-....
 
-8. Install test chaincode on operator cluster
+6. Install chaincode test
 ```
-curl -s -X POST   http://admin-rca-ica.ordererhai:4001/chaincodes   -H "content-type: application/json"   -d '{
-  "orgname":"mambatest",
+curl -s -X POST   http://admin-rca-ica.akc:4001/chaincodes   -H "content-type: application/json"   -d '{
+  "orgname":"akc",
   "chaincodeId":"fabcar",
   "chaincodePath":"chaincodes/fabcar/",
   "chaincodeVersion":"v1.0",
@@ -46,32 +48,23 @@ curl -s -X POST   http://admin-rca-ica.ordererhai:4001/chaincodes   -H "content-
 }'
 ```
 
-9. In merchant cluster:
-
-- Copy ica-orderer-ca-chain.pem from operator (/tmp/artifact/cluster-operator-demo/akc-ca-data/ica-orderer-ca-chain.pem) to merchant cluster (same path)
+7. Copy signed cert of orderer and akc org to merchant cluster
 ```
-cp /tmp/artifact/cluster-example/akc-ca-data/ica-orderer-ca-chain.pem /tmp/artifact/cluster-merchant-example/akc-ca-data/
+cp /tmp/artifact/akc-network/akc-ca-data/ica-orderer-ca-chain.pem /tmp/artifact/merchant-network/akc-ca-data/
+cp /tmp/artifact/akc-network/akc-ca-data/ica-akc-ca-chain.pem /tmp/artifact/merchant-network/akc-ca-data/
 ```
 
-- Register new user for new org
+8. Join merchant to channel
 ```
 curl -s -X POST   http://admin-rca-ica.default:4001/registerUser   -H "content-type: application/json"   -d '{
-  "orgname":"remotetest"
+  "orgname":"merchant"
 }'
-```
-
-- Join channel
-```
 curl -s -X POST   http://admin-rca-ica.default:4001/joinchannel   -H "content-type: application/json"   -d '{
-  "orgname":"remotetest",
-  "channelName":"akctestchannel"
+  "orgname":"merchant",
+  "channelName":"akcchannel"
 }'
-```
-
-- Install test chain code
-```
 curl -s -X POST   http://admin-rca-ica.default:4001/chaincodes   -H "content-type: application/json"   -d '{
-  "orgname":"remotetest",
+  "orgname":"merchant",
   "chaincodeId":"fabcar",
   "chaincodePath":"chaincodes/fabcar/",
   "chaincodeVersion":"v1.0",
@@ -79,28 +72,23 @@ curl -s -X POST   http://admin-rca-ica.default:4001/chaincodes   -H "content-typ
 }'
 ```
 
-Note:
-
-If endorsement policy is all org, you must send tlsca cert between endorsement peers.
-  Merchant send operator -> Operator edit network config
-  Operator gui merchant -> Merchant edit network config
-
-
-10. Init/Upgrade chaincode on Operator cluster
+9. Init or upgrade chaincode on operator cluster
+- Init
 ```
-
-curl -s -X POST   http://admin-rca-ica.ordererhai:4001/initchaincodes   -H "content-type: application/json"   -d '{
-  "orgname":"mambatest",
-  "channelName":"akctestchannel",
+curl -s -X POST   http://admin-rca-ica.akc:4001/initchaincodes   -H "content-type: application/json"   -d '{
+  "orgname":"akc",
+  "channelName":"akcchannel",
   "chaincodeId":"fabcar",
   "chaincodeVersion":"v1.0",
   "chaincodeType":"golang",
   "args":[]
 }'
-
+```
+- Or upgrade if chaincode exists
+```
 curl -s -X POST   http://admin-rca-ica.ordererhai:4001/upgradeChainCode   -H "content-type: application/json"   -d '{
-  "orgname":"mambatest",
-  "channelName":"akctestchannel",
+  "orgname":"akc",
+  "channelName":"akcchannel",
   "chaincodeId":"fabcar",
   "chaincodeVersion":"v1.0",
   "chaincodeType":"golang",
@@ -108,11 +96,19 @@ curl -s -X POST   http://admin-rca-ica.ordererhai:4001/upgradeChainCode   -H "co
 }'
 ```
 
-11. Try invoke chaincode on merchant cluster:
+10. Try invoke chaincode on merchant cluster:
 ```
 curl -s -X POST   http://admin-rca-ica.default:4001/invokeChainCode   -H "content-type: application/json"   -d '{
-  "orgname":"remotetest",
-  "channelName":"akctestchannel",
+  "orgname":"merchant",
+  "channelName":"akcchannel",
+  "chaincodeId":"fabcar",
+  "args": ["CAR1", "a", "b", "c", "d"],
+  "fcn": "createCar"
+}'
+
+curl -s -X POST   http://admin-rca-ica.akc:4001/invokeChainCode   -H "content-type: application/json"   -d '{
+  "orgname":"akc",
+  "channelName":"akcchannel",
   "chaincodeId":"fabcar",
   "args": ["CAR1", "a", "b", "c", "d"],
   "fcn": "createCar"

--- a/mamba/blockchain/create_org/commands.py
+++ b/mamba/blockchain/create_org/commands.py
@@ -43,6 +43,8 @@ def create_new_org():
     # Run jobs to register peers
     reg_all_peer()
 
+    time.sleep(1)
+
     # Run jobs to enroll peers
     enroll_all_peer()
 

--- a/mamba/blockchain/explorer/commands.py
+++ b/mamba/blockchain/explorer/commands.py
@@ -207,7 +207,8 @@ def setup_explorer():
         'DATABASE_PASSWORD': 'Akachain',
         'EFS_SERVER': settings.EFS_SERVER,
         'EFS_PATH': settings.EFS_PATH,
-        'EFS_EXTEND': settings.EFS_EXTEND
+        'EFS_EXTEND': settings.EFS_EXTEND,
+        'PVS_PATH': settings.PVS_PATH
     }
 
     # Deploy explorer db sts

--- a/mamba/blockchain/template/explorer/explorer-deployment.yaml
+++ b/mamba/blockchain/template/explorer/explorer-deployment.yaml
@@ -45,16 +45,16 @@ spec:
       - name: crypto-config
         nfs:
           server: {{EFS_SERVER}}
-          path: /pvs/{{EFS_PATH}}/{{EFS_EXTEND}}/akc-ca-data/crypto-config/
+          path: {{PVS_PATH}}/{{EFS_PATH}}/{{EFS_EXTEND}}/akc-ca-data/crypto-config/
       - name: explorer-config
         nfs:
           server: {{EFS_SERVER}}
-          path: /pvs/{{EFS_PATH}}/{{EFS_EXTEND}}/explorer-config/
+          path: {{PVS_PATH}}/{{EFS_PATH}}/{{EFS_EXTEND}}/explorer-config/
       - name: crypto-store-efs
         nfs:
           server: {{EFS_SERVER}}
-          path: /pvs/{{EFS_PATH}}/{{EFS_EXTEND}}/admin/crypto-store/
+          path: {{PVS_PATH}}/{{EFS_PATH}}/{{EFS_EXTEND}}/admin/crypto-store/
       - name: crypto-path-efs
         nfs:
           server: {{EFS_SERVER}}
-          path: /pvs/{{EFS_PATH}}/{{EFS_EXTEND}}/admin/crypto-path/
+          path: {{PVS_PATH}}/{{EFS_PATH}}/{{EFS_EXTEND}}/admin/crypto-path/

--- a/mamba/blockchain/template/ica-ex/fabric-deployment-ica.yaml
+++ b/mamba/blockchain/template/ica-ex/fabric-deployment-ica.yaml
@@ -62,11 +62,11 @@ spec:
        - name: scripts
          nfs:
           server: {{EFS_SERVER}}
-          path: /pvs/{{EFS_PATH}}/{{EFS_EXTEND}}/akc-ca-scripts/
+          path: {{PVS_PATH}}/{{EFS_PATH}}/{{EFS_EXTEND}}/akc-ca-scripts/
        - name: data
          nfs:
           server: {{EFS_SERVER}}
-          path: /pvs/{{EFS_PATH}}/{{EFS_EXTEND}}/akc-ca-data/
+          path: {{PVS_PATH}}/{{EFS_PATH}}/{{EFS_EXTEND}}/akc-ca-data/
   volumeClaimTemplates:
   - metadata:
       name: {{ICA_NAME}}-pvc

--- a/mamba/blockchain/template/peer-sts/peer-stateful.yaml
+++ b/mamba/blockchain/template/peer-sts/peer-stateful.yaml
@@ -91,7 +91,7 @@ spec:
         command: ["sh", "-c", "peer node start"]
         env:
         - name: CORE_CHAINCODE_BUILDER
-          value: hyperledger/fabric-ccenv:{{FABRIC_TAG}}
+          value: hyperledger/fabric-ccenv:1.4.1
         - name: CORE_PEER_ID
           value: peer{{PEER_INDEX}}-{{PEER_ORG}}.{{PEER_DOMAIN}}
         - name: CORE_PEER_GOSSIP_BOOTSTRAP

--- a/mamba/blockchain/template/prometheus/prometheus-stateful.yaml
+++ b/mamba/blockchain/template/prometheus/prometheus-stateful.yaml
@@ -40,4 +40,4 @@ spec:
       - name: prometheus-config
         nfs:
           server: {{EFS_SERVER}}
-          path: /pvs/{{EFS_PATH}}/{{EFS_EXTEND}}/promconfig/
+          path: {{PVS_PATH}}/{{EFS_PATH}}/{{EFS_EXTEND}}/promconfig/

--- a/mamba/blockchain/update_channel_config/commands.py
+++ b/mamba/blockchain/update_channel_config/commands.py
@@ -28,7 +28,8 @@ def fetch_config(org=None, domain=None):
         'CHANNEL_NAME': settings.CHANNEL_NAME,
         'EFS_SERVER': settings.EFS_SERVER,
         'EFS_PATH': settings.EFS_PATH,
-        'EFS_EXTEND': settings.EFS_EXTEND
+        'EFS_EXTEND': settings.EFS_EXTEND,
+        'PVS_PATH': settings.PVS_PATH
     }
     k8s_template_file = '%s/add-org/2fetch-channel.yaml' % util.get_k8s_template_path()
     settings.k8s.apply_yaml_from_template(
@@ -43,7 +44,8 @@ def modify_config(domain=None):
         'NEW_ORG_NAME': settings.NEW_ORG_NAME,
         'EFS_SERVER': settings.EFS_SERVER,
         'EFS_PATH': settings.EFS_PATH,
-        'EFS_EXTEND': settings.EFS_EXTEND
+        'EFS_EXTEND': settings.EFS_EXTEND,
+        'PVS_PATH': settings.PVS_PATH
     }
     k8s_template_file = '%s/add-org/3modifyingorgmaterial.yaml' % util.get_k8s_template_path()
     settings.k8s.apply_yaml_from_template(
@@ -59,7 +61,8 @@ def create_config_update_pb(domain=None):
         'CHANNEL_NAME': settings.CHANNEL_NAME,
         'EFS_SERVER': settings.EFS_SERVER,
         'EFS_PATH': settings.EFS_PATH,
-        'EFS_EXTEND': settings.EFS_EXTEND
+        'EFS_EXTEND': settings.EFS_EXTEND,
+        'PVS_PATH': settings.PVS_PATH
     }
     k8s_template_file = '%s/add-org/4createconfigupdate.yaml' % util.get_k8s_template_path()
     settings.k8s.apply_yaml_from_template(
@@ -78,7 +81,8 @@ def update_channel_config(org=None, domain=None):
         'ORDERER_DOMAIN': settings.ORDERER_DOMAINS,
         'EFS_SERVER': settings.EFS_SERVER,
         'EFS_PATH': settings.EFS_PATH,
-        'EFS_EXTEND': settings.EFS_EXTEND
+        'EFS_EXTEND': settings.EFS_EXTEND,
+        'PVS_PATH': settings.PVS_PATH
     }
     k8s_template_file = '%s/add-org/6updatechannelconfig.yaml' % util.get_k8s_template_path()
     settings.k8s.apply_yaml_from_template(

--- a/mamba/config/operator.env-template
+++ b/mamba/config/operator.env-template
@@ -1,6 +1,6 @@
 ##--START REPLACE CONTENTS--##
 
-# K8s type
+# K8s type: minikube or eks
 K8S_TYPE="minikube"
 
 # If you run mamba with K8S_TYPE="eks"
@@ -73,16 +73,20 @@ PRIVATE_DOCKER_EMAIL="mamba@akchain.io"
 # The tag of the docker images to download for Fabric CA and Fabric. Equates to the Fabric version
 FABRIC_TAG="1.4.1"
 
-# Fill this if you're using remote org
+# EXTERNAL_ORDERER_ADDRESSES: Using when register DNS of orderer's certificate. The remote org can connect to the orderer via this address.
+# EXTERNAL_ORG_PEERX_ADDRESSES: Using when register DNS of peerX's certificate. When the endorsement policy is set ALL_ENDORSEMENT (default), 
+#       the client must send a transaction proposal to all endorse peers. This config will help the peer expose using a domain to keep the connection with the remote client.
+# EXTERNAL_RCA_ADDRESSES: Using when register DNS of root CA's certificate. The intermediate CA of remote org can connect to the root CA via this address.
 EXTERNAL_ORDERER_ADDRESSES="" # ex: orderer.example.com
 EXTERNAL_ORG_PEER0_ADDRESSES="" # ex: peer0-external-org.example.com
 EXTERNAL_ORG_PEER1_ADDRESSES="" # ex: peer1-external-org.example.com
 EXTERNAL_RCA_ADDRESSES=""
 
 ################# Add org
+# Setting this config before running command: "mamba channel-config auto-update" in all cluster except new org's cluster
 NEW_ORG_NAME="neworg"
 
-# Endorsement org infomation
+# Specify endorsement org information base on endorsement policy
 ENDORSEMENT_ORG_NAME="" # ex: peer0-operator.example peer1-operator.example
 ENDORSEMENT_ORG_ADDRESS="" # ex: peer0-operator.example.com peer1-operator.example.com
 ENDORSEMENT_ORG_TLSCERT="" # ex: ica-operator-ca-chain.pem ica-operator-ca-chain.pem


### PR DESCRIPTION
- Optimize create_org command by add time sleep between register peer identity and enroll peer
- Fix missing PVS_PATH env in some commands: explorer, external intermediate CA, Prometheus and update the channel config.
- Update the comment in the environment template file.
- Fix the version of hyperledger/fabric-ccenv to 1.4.1.